### PR TITLE
feat(constiquiz): add quiz status pages and submission confirmation dialog

### DIFF
--- a/src/routes/consti-quiz/+page.server.js
+++ b/src/routes/consti-quiz/+page.server.js
@@ -12,7 +12,10 @@ export async function load({ locals }) {
         console.error(error);
     }
 
+    //*
     const hasSubmitted = data && data.length;
+    /*/ const hasSubmitted = false; //*/
+    const isOpen = true;
 
-    return { hasSubmitted };
+    return { hasSubmitted, isOpen };
 }

--- a/src/routes/consti-quiz/+page.svelte
+++ b/src/routes/consti-quiz/+page.svelte
@@ -8,11 +8,14 @@
     import Section from './Section.svelte';
     import SectionNav from './SectionNav.svelte';
     import ShortTextQuestion from './ShortTextQuestion.svelte';
+    import QuizClosedPage from './QuizClosedPage.svelte';
+    import QuizSummaryPage from './QuizSummaryPage.svelte';
+
     import { browser } from '$app/environment';
     import { onMount } from 'svelte';
 
     const { data } = $props();
-    const { user, sections, questions, answers, hasSubmitted } = data;
+    const { user, sections, questions, answers, hasSubmitted, isOpen } = data;
 
     const questionIdToPoints = {
         '1100': 1,
@@ -200,11 +203,20 @@
 
 <div class="my-12 flex h-screen bg-[#161619] text-[#F9FAFB]">
     {#if hasSubmitted}
-        <!--  TODO: Improve UI  -->
-        <div>
-            <h1>You're done</h1>
-            <p>Your Score: {checkedPoints}/{totalPoints}</p>
-            <p>Total points of unchecked items: {uncheckedPoints}</p>
+        <!-- Content area -->
+        <div class="font-inter h-screen flex-1 flex-row bg-[#161619] px-4 py-6 sm:px-6 lg:px-10">
+            <!-- Main Content -->
+            <main class="mt-6 flex flex-col lg:flex-row lg:justify-evenly">
+                <QuizSummaryPage {checkedPoints} {uncheckedPoints} {totalPoints} />
+            </main>
+        </div>
+    {:else if !isOpen}
+        <!-- Content area -->
+        <div class="font-inter h-screen flex-1 flex-row bg-[#161619] px-4 py-6 sm:px-6 lg:px-10">
+            <!-- Main Content -->
+            <main class="mt-6 flex flex-col lg:flex-row lg:justify-evenly">
+                <QuizClosedPage />
+            </main>
         </div>
     {:else}
         <!-- Right side container (flexbox column) -->
@@ -244,7 +256,7 @@
                                         bind:value={sectionToAnswers[section_id]![i]!}
                                     />
                                 {:else if question.type === 'radio'}
-                                    {#if question.title === 'What is the hex code of CSI Blue?'}
+                                    {#if question.section.title === 'Bonus'}
                                         <RadioQuestion
                                             title={question.title}
                                             bind:value={sectionToAnswers[section_id]![i]}

--- a/src/routes/consti-quiz/ConfirmationDialog.svelte
+++ b/src/routes/consti-quiz/ConfirmationDialog.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+    import type { Snippet } from 'svelte';
+
+    type Props = {
+        showModal: boolean;
+        onConfirm: () => Promise<void>;
+        //children?: Snippet;
+    };
+
+    let { showModal = $bindable(false), onConfirm,/* children*/ } = $props();
+
+    let dialog = $state();
+
+    $effect(() => {
+        //console.log("showModal:",showModal);
+        if (showModal) dialog.showModal();
+    });
+</script>
+
+<div class="flex h-full w-full">
+<dialog
+    class="m-auto min-h-2/12 min-w-4/12 max-h-3/12 max-w-6/12 bg-transparent text-[#F9FAFB]"
+    bind:this={dialog}
+    onclose={() => (showModal = false)}
+    onclick={e => {
+        if (e.target === dialog) dialog.close();
+    }}
+>
+    <div class="bg-csi-neutral-900 flex h-full w-full flex-col gap-y-2.5 rounded-2xl p-6">
+        <div class="mb-2">
+            <!-- {@render children?.()} -->
+    <h2 class="text-white mb-4 text-3xl font-bold">Submit Quiz</h2>
+            <p class="text-justify">
+            Please take your time and check your answers before submitting.
+            Once you submit, you may no longer change or review your answers.
+            </p>
+        </div>
+        <div class="flex flex-row gap-x-4 justify-center">
+        <button
+            class="bg-csi-grey rounded-lg px-4 py-2 font-semibold text-white shadow-lg transition-colors hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-50"
+            autofocus
+            onclick={async () => {
+                dialog.close();
+                await onConfirm();
+            }}
+        >
+            Confirm
+        </button>
+        <button
+            class="bg-csi-grey rounded-lg px-4 py-2 font-semibold text-white shadow-lg transition-colors hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-50"
+            autofocus
+            onclick={() => dialog.close()}
+        >
+            Cancel
+        </button>
+        </div>
+    </div>
+</dialog>
+</div>
+
+<style>
+    dialog::backdrop {
+        background: rgba(0, 0, 0, 0.6);
+    }
+    dialog > div {
+        padding: 1em;
+    }
+</style>

--- a/src/routes/consti-quiz/QuizClosedPage.svelte
+++ b/src/routes/consti-quiz/QuizClosedPage.svelte
@@ -1,0 +1,8 @@
+<!--  TODO: Improve UI  -->
+<!-- 
+<div class="bg-csi-neutral-900 mb-8 flex flex-col gap-y-2.5 rounded-2xl p-6 h-min w-max">
+-->
+<div class="flex flex-col justify-center text-center">
+    <h2 class="text-csi-blue mb-4 text-3xl font-bold">Constiquiz Closed</h2>
+    <p>The Constiquiz Module is closed. Please check again later.</p>
+</div>

--- a/src/routes/consti-quiz/QuizSummaryPage.svelte
+++ b/src/routes/consti-quiz/QuizSummaryPage.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+    type Props = {
+        checkedPoints: number;
+        uncheckedPoints: number;
+        totalPoints: number;
+    };
+
+    const { checkedPoints, uncheckedPoints, totalPoints }: Props = $props();
+</script>
+
+<!--  TODO: Improve UI  -->
+<div class="bg-csi-neutral-900 mb-8 flex h-min w-1/2 flex-col gap-y-2.5 rounded-2xl p-6">
+    <h2 class="text-csi-blue text-3xl font-bold">Constiquiz Submitted</h2>
+    <p class="text-justify">
+        Your answers have been submitted, but your grade is not yet complete. The score below shows the calculated score
+        for the <em>close-ended questions</em>. We are currently in the process of grading your responses to the
+        <em>open-ended questions</em>. We will update you when your scores are released.
+    </p>
+    <p>Calculated Score: {checkedPoints}/{totalPoints}</p>
+    <p>Total points of unchecked items: {uncheckedPoints}</p>
+</div>

--- a/src/routes/consti-quiz/SaveButton.svelte
+++ b/src/routes/consti-quiz/SaveButton.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+    import ConfirmationDialog from './ConfirmationDialog.svelte';
+
     const { saveAnswers, submitAnswers } = $props();
+
+    let showModal = $state(false);
 
     let isSaving = $state(false);
     let isSubmitting = $state(false);
@@ -70,6 +74,7 @@
 </script>
 
 <div class="fixed bottom-8 left-1/2 z-30 flex -translate-x-1/2 transform flex-col items-center space-y-2 md:left-1/5">
+    <ConfirmationDialog bind:showModal onConfirm={handleSubmit} />
     <div class="flex gap-4">
         <button
             onclick={async () => {
@@ -82,7 +87,10 @@
         </button>
 
         <button
-            onclick={handleSubmit}
+            onclick={async () => {
+                //await handleSubmit();
+                showModal = true;
+            }}
             class="bg-csi-grey rounded-lg px-4 py-2 font-semibold text-white shadow-lg transition-colors hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-50"
             disabled={isSubmitting || isSaving}
         >


### PR DESCRIPTION
# Constiquiz Changes

## Done

- modify logic for changing page content depending on quiz status (e.g., closed, submitted, etc.)
- add status page for closed quiz
- modify status page for submitted quiz
- create `ConfirmationDialog` component
- add confirmation functionality when submitting
- modify question rendering logic for "Bonus" section questions